### PR TITLE
FIX: uninlined_format_args clippy warning

### DIFF
--- a/src/lanscan_device_info_backend.rs
+++ b/src/lanscan_device_info_backend.rs
@@ -21,10 +21,10 @@ impl DeviceInfoBackend {
         // Vulnerabilities have a possibility of change, so we include it
         let mut sorted_vulnerabilities = self.vulnerabilities.clone();
         sorted_vulnerabilities.sort_by(|a, b| a.name.cmp(&b.name));
-        hasher.update(format!("{:?}", sorted_vulnerabilities).as_bytes());
+        hasher.update(format!("{sorted_vulnerabilities:?}").as_bytes());
         let mut sorted_open_ports = self.open_ports.clone();
         sorted_open_ports.sort_by(|a, b| a.port.cmp(&b.port));
-        hasher.update(format!("{:?}", sorted_open_ports).as_bytes());
+        hasher.update(format!("{sorted_open_ports:?}").as_bytes());
         hasher.finalize().to_hex().to_string()
     }
 }

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -111,7 +111,7 @@ pub fn generate_signature(secret: &str, request_id: &str) -> (String, String) {
     let timestamp = Utc::now().timestamp() as u64;
 
     // Prepare data to sign: concatenate timestamp and request_id
-    let data = format!("{}{}", timestamp, request_id);
+    let data = format!("{timestamp}{request_id}");
 
     // Create HMAC-SHA256 instance with the secret key
     let mut mac =
@@ -157,13 +157,13 @@ fn verify_signature_cmd(
     if !no_timestamp_check {
         let current_time = Utc::now().timestamp() as u64;
         if (current_time as i64 - timestamp as i64).abs() > 300 {
-            let error = format!("bad timestamp: {} != {}", timestamp, current_time);
+            let error = format!("bad timestamp: {timestamp} != {current_time}");
             return Err(anyhow!(error));
         }
     }
 
     // Recreate the data to sign
-    let data_to_sign = format!("{}{}", timestamp, request_id);
+    let data_to_sign = format!("{timestamp}{request_id}");
 
     // Create HMAC instance with the secret
     let mut mac =
@@ -175,13 +175,13 @@ fn verify_signature_cmd(
         Ok(decoded_signature) => {
             let ok = mac.verify_slice(&decoded_signature).is_ok();
             if !ok {
-                let error = format!("slice verification failed for {:?}", received_signature);
+                let error = format!("slice verification failed for {received_signature:?}");
                 return Err(anyhow!(error));
             };
             Ok(())
         }
         Err(_) => {
-            let error = format!("failed to decode signature: {:?}", received_signature);
+            let error = format!("failed to decode signature: {received_signature:?}");
             Err(anyhow!(error))
         }
     }


### PR DESCRIPTION
# Pull request
Fix the clippy warning about the uninlined_format_args clippy warning
## Issue referencing
closes #

## Describe your changes

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have added tests to prove that my code is effective
- [ ] I have made the corresponding changes to the documentation

## Additional notes

